### PR TITLE
Made it build with Visual Studio 2013

### DIFF
--- a/src/utilities/cxx/stdio.cxx
+++ b/src/utilities/cxx/stdio.cxx
@@ -16,8 +16,9 @@
 #include <basis/assert.h> // assert()
 
 #include <stdlib.h>       // getenv()
+#include <algorithm>      // min()
 
-#if WINDOWS
+#if _WINDOWS
 #  include <windows.h>    // GetConsoleScreenBufferInfo()
 #else
 #  include <unistd.h>     // STDOUT_FILENO


### PR DESCRIPTION
- Must include \<algorithm> instead of \<stdlib.h> to get the `min()`function
- The preprocessor define for Windows is called `_WINDOWS`, not `WINDOWS`